### PR TITLE
Fix tests on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,6 @@ jobs:
 
     - run: opam depext --yes conf-postgresql
     - run: opam depext --yes conf-libev
-    # Needed until https://github.com/reasonml/reason/pull/2660 is in opam.
-    - run: opam pin add reason --yes --no-action --dev-repo
     - run: opam install --yes --deps-only --with-test ./dream-pure.opam ./dream-httpaf.opam ./dream.opam
     - run: opam exec -- dune runtest
     - run: |

--- a/dream.opam
+++ b/dream.opam
@@ -50,7 +50,7 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "1.6.0"}  # https://github.com/aantron/dream/issues/44.
+  "caqti" {>= "1.6.0" & <= "1.7.0"}  # https://github.com/aantron/dream/issues/44.
   "caqti-lwt"
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}

--- a/example/quickstart.sh
+++ b/example/quickstart.sh
@@ -3,7 +3,7 @@
 set -e
 
 EXAMPLE=2-middleware
-REPO=https://github.com/aantron/dream
+REPO=https://github.com/beajeanm/dream
 if [ "$1" == "" ]
 then
   REF=master

--- a/example/r-fullstack-melange/esy.json
+++ b/example/r-fullstack-melange/esy.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "melange": "melange-re/melange",
     "ocaml": "4.12.x"
   },

--- a/example/r-graphql/esy.json
+++ b/example/r-graphql/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "ocaml": "4.12.x"
   },
   "devDependencies": {

--- a/example/r-hello/esy.json
+++ b/example/r-hello/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "ocaml": "4.12.x"
   },
   "devDependencies": {

--- a/example/r-template-logic/esy.json
+++ b/example/r-template-logic/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "ocaml": "4.12.x"
   },
   "devDependencies": {

--- a/example/r-template-stream/esy.json
+++ b/example/r-template-stream/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "ocaml": "4.12.x"
   },
   "devDependencies": {

--- a/example/r-template/esy.json
+++ b/example/r-template/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "ocaml": "4.12.x"
   },
   "devDependencies": {

--- a/example/r-tyxml/README.md
+++ b/example/r-tyxml/README.md
@@ -44,7 +44,7 @@ To get this, we depend on package `tyxml-jsx` in
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "@opam/tyxml": "*",
     <b>"@opam/tyxml-jsx": "*",</b>
     "ocaml": "4.12.x"

--- a/example/r-tyxml/esy.json
+++ b/example/r-tyxml/esy.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@opam/dream": "1.0.0~alpha4",
     "@opam/dune": "^2.0",
-    "@opam/reason": "^3.7.0",
+    "@opam/reason": "^3.8.0",
     "@opam/tyxml": "*",
     "@opam/tyxml-jsx": "*",
     "ocaml": "4.12.x"

--- a/example/z-playground/opam-switch
+++ b/example/z-playground/opam-switch
@@ -95,7 +95,7 @@ installed: [
   "psq.0.2.0"
   "ptime.0.8.6"
   "re.1.10.3"
-  "reason.3.7.0"
+  "reason.3.8.0"
   "result.1.5"
   "rresult.0.7.0"
   "seq.base"

--- a/test/expect/pure/stream/stream.ml
+++ b/test/expect/pure/stream/stream.ml
@@ -116,18 +116,18 @@ let%expect_test _ =
 let%expect_test _ =
   let stream = Stream.empty in
   (try write_and_dump stream Bigstringaf.empty 0 0 false false
-  with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  with Failure msg -> print_endline msg);
   (try flush_and_dump stream
-  with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  with Failure msg -> print_endline msg);
   (try ping_and_dump "foo" stream
-  with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  with Failure msg -> print_endline msg);
   (try pong_and_dump "bar" stream
-  with Failure _ as exn -> print_endline (Printexc.to_string exn));
+  with Failure msg -> print_endline msg);
   [%expect {|
-    (Failure "write to a read-only stream")
-    (Failure "flush of a read-only stream")
-    (Failure "ping on a read-only stream")
-    (Failure "pong on a read-only stream") |}]
+    write to a read-only stream
+    flush of a read-only stream
+    ping on a read-only stream
+    pong on a read-only stream |}]
 
 
 
@@ -138,8 +138,8 @@ let%expect_test _ =
   let stream = Stream.stream reader writer in
   read_and_dump stream;
   try read_and_dump stream
-  with Failure _ as exn -> print_endline (Printexc.to_string exn);
-  [%expect {| (Failure "stream read: the previous read has not completed") |}]
+  with Failure msg -> print_endline msg;
+  [%expect {| stream read: the previous read has not completed |}]
 
 
 


### PR DESCRIPTION
* The pin of reason is no longer necessary as reason 3.8 supports ocaml 4.13
* Fix a higher bond to caqti. Caqti 1.8 introduces new deprecations that would
  require code change.
* The behavior of `Printexec.to_string (Failure "msg")` has changed from 4.09
  to 4.10. It used to be `(Failure "write to a read-only stream")` but it'
  now `Failure ("write to a read-only stream")`.
  Since we already know the exception type, I figure it would be enough to
  match on the message itself.
